### PR TITLE
change "fedora 34" to "fedora 35" in error message

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -131,7 +131,7 @@ os_check(){
         fi
     elif [ "$lsb_dist" = "fedora" ]; then
         if [ "$dist_version" != "35" ]; then
-            output "Unsupported Fedora version. Only Fedora 34 is supported."
+            output "Unsupported Fedora version. Only Fedora 35 is supported."
             exit 2
         fi
     elif [ "$lsb_dist" = "centos" ]; then


### PR DESCRIPTION
was just reading through the script before installing pterodactyl